### PR TITLE
changed particle args to dict, added spawning variability, changed ca…

### DIFF
--- a/robot_localization/pf.py
+++ b/robot_localization/pf.py
@@ -33,7 +33,7 @@ class Particle(object):
             w: the particle weight (the class does not ensure that particle weights are normalized
     """
 
-    def __init__(self, parent_particle=None, pose_and_ranges={'coords':[(0.0, 0.0),.5],'theta':[0.0,pi/2]}):
+    def __init__(self, parent_particle=None, pose_and_ranges={'coords': [(0.0, 0.0), .5], 'theta': [0.0, pi/2]}):
         """ Construct a new Particle
             parent_particle: Particle object used to generate reseeded Particle object
             pose_and_ranges: Dictionary with string keys and list values. Item 0 in list is the value and 
@@ -48,11 +48,14 @@ class Particle(object):
 
         self.poses_and_ranges = pose_and_ranges
         self.w = 1.0
-        
+
         # use 1/3 of soft max ranges to get standard deviation for generation
-        self.theta = random.gauss(self.poses_and_ranges['theta'][0], self.poses_and_ranges['theta'][1]/3)
-        self.x = random.gauss(self.poses_and_ranges['coords'][0][0], self.poses_and_ranges['coords'][1]/3)
-        self.y = random.gauss(self.poses_and_ranges['coords'][0][1], self.poses_and_ranges['coords'][1]/3)
+        self.theta = random.gauss(
+            self.poses_and_ranges['theta'][0], self.poses_and_ranges['theta'][1]/3)
+        self.x = random.gauss(
+            self.poses_and_ranges['coords'][0][0], self.poses_and_ranges['coords'][1]/3)
+        self.y = random.gauss(
+            self.poses_and_ranges['coords'][0][1], self.poses_and_ranges['coords'][1]/3)
 
     def get_transform(self):
         """
@@ -401,12 +404,15 @@ class ParticleFilter(Node):
             xy_theta = self.transform_helper.convert_pose_to_xy_and_theta(
                 self.odom_pose)
         xy_range = .8           # cartesian soft max (3x standard deviation)
-        theta_range = pi/2        # angle radians soft max (3x standard deviation)
+        # angle radians soft max (3x standard deviation)
+        theta_range = pi/2
 
         self.particle_cloud = []
-        pose_and_ranges={'coords':[(xy_theta[0], xy_theta[1]),xy_range],'theta':[xy_theta[2],theta_range]}
+        pose_and_ranges = {'coords': [(xy_theta[0], xy_theta[1]), xy_range], 'theta': [
+            xy_theta[2], theta_range]}
         for _ in range(self.n_particles):
-            self.particle_cloud.append(Particle(pose_and_ranges=pose_and_ranges))
+            self.particle_cloud.append(
+                Particle(pose_and_ranges=pose_and_ranges))
 
         self.normalize_particles()
 


### PR DESCRIPTION
…ll locations and names of some functions for clarity



-I changed standard deviations to "soft maxes" which are 3 standard deviations because it felt more clear to me for when we tune the algorithm, if you don't like this feel free to remove it and change these back to std dev

-changed inputs to particle to a dictionary format. Open to other options for this, or initializing a variable for the theta x and y terms of the dictionary so that the code extracting this is cleaner looking. Dictionaries were chosen because I want each value to explicitly represent a term rather than be based on ordering of an array or list. Couldn't think of a better way to do that, if you can though I'm welcome to it

-removed weight input to particles because it didn't fit with the convention of input point and range and after a sanity check realized that we wouldn't really want to input a particular weight anyway. Also the weights are normalized/recalculated outside of initialization of particles before they mean anything. Welcome to have discussion on this point as well, especially discussion about what we do when to the particles. I think little flow charts of operations like this is what separates a good from a great writeup so I can try to do that when we are working on it.

-moved the locations of calling update robot pose to the main loop or whichever function calls initialize particle cloud (there's one ros subscription that can do it) because it felt weird that it was being called by a function instead of shown in the main loop that we are updating pose